### PR TITLE
SINF-254 - increase ES node count to 2

### DIFF
--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -34,7 +34,8 @@ resource "aws_elasticsearch_domain" "main" {
   elasticsearch_version = "7.4"
 
   cluster_config {
-    instance_type = var.es_instance_type
+    instance_type  = var.es_instance_type
+    instance_count = 2
   }
 
   ebs_options {


### PR DESCRIPTION
Increase Elasticsearch node count to '2'. Deployed on SBX1.