### PR TITLE
SINF-256 - applied sizing from infra spreadsheet

### DIFF
--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -41,4 +41,6 @@ module "deploy" {
   enabled_cloudwatch_logs_exports = ["postgresql"]
   snapshot_identifier             = "arn:aws:rds:eu-west-2:${data.aws_ssm_parameter.aws_account_id.value}:cluster-snapshot:scale-bat-spree-seeded"
   kms_cmk_rds_shared              = data.aws_ssm_parameter.kms_cmk_rds_shared.value
+  es_instance_type                = "m5.large.elasticsearch"
+  db_instance_class               = "db.r5.large"
 }

--- a/terraform/environments/int/main.tf
+++ b/terraform/environments/int/main.tf
@@ -41,4 +41,6 @@ module "deploy" {
   enabled_cloudwatch_logs_exports = ["postgresql"]
   kms_cmk_rds_shared              = data.aws_ssm_parameter.kms_cmk_rds_shared.value
   snapshot_identifier             = "arn:aws:rds:eu-west-2:${data.aws_ssm_parameter.aws_account_id.value}:cluster-snapshot:scale-bat-spree-seeded-with-images"
+  es_instance_type                = "m5.large.elasticsearch"
+  db_instance_class               = "db.r5.large"
 }

--- a/terraform/environments/sbx8/main.tf
+++ b/terraform/environments/sbx8/main.tf
@@ -40,4 +40,6 @@ module "deploy" {
   skip_final_snapshot             = false
   enabled_cloudwatch_logs_exports = ["postgresql"]
   kms_cmk_rds_shared              = data.aws_ssm_parameter.kms_cmk_rds_shared.value
+  es_instance_type                = "m5.xlarge.elasticsearch"
+  db_instance_class               = "db.r5.xlarge"
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -81,5 +81,6 @@ module "elasticsearch" {
   private_app_subnet_ids = split(",", data.aws_ssm_parameter.private_app_subnet_ids.value)
   security_group_ids     = concat(local.cidr_blocks_allowed_external_ccs, local.cidr_blocks_allowed_external_spark, tolist([data.aws_vpc.scale.cidr_block]))
   es_instance_type       = var.es_instance_type
+  es_instance_count      = var.es_instance_count
   es_ebs_volume_size     = var.es_ebs_volume_size
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -43,6 +43,11 @@ variable "es_instance_type" {
   default = "t2.medium.elasticsearch"
 }
 
+variable "es_instance_count" {
+  type    = number
+  default = 2
+}
+
 variable "es_ebs_volume_size" {
   type    = number
   default = 10

--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -35,7 +35,7 @@ resource "aws_elasticsearch_domain" "main" {
 
   cluster_config {
     instance_type  = var.es_instance_type
-    instance_count = 2
+    instance_count = var.es_instance_count
   }
 
   ebs_options {

--- a/terraform/modules/elasticsearch/variables.tf
+++ b/terraform/modules/elasticsearch/variables.tf
@@ -18,6 +18,10 @@ variable "es_instance_type" {
   type = string
 }
 
+variable "es_instance_count" {
+  type = number
+}
+
 variable "es_ebs_volume_size" {
   type = number
 }


### PR DESCRIPTION
Applied values from Som's spreadsheet - also applied for DEV & INT as they are different from what is already there.

Som specified a storage size of 20/20/100GB for the database for DEV/INT/SBX8 - but as far as I know you don't specify that for Aurora - it just scales automatically - I think that is correct?