### PR TITLE
SINF-256 - enabled multi-AZ on Elasticsearch

### DIFF
--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -34,8 +34,13 @@ resource "aws_elasticsearch_domain" "main" {
   elasticsearch_version = "7.4"
 
   cluster_config {
-    instance_type  = var.es_instance_type
-    instance_count = var.es_instance_count
+    instance_type          = var.es_instance_type
+    instance_count         = var.es_instance_count
+    zone_awareness_enabled = true
+
+    zone_awareness_config {
+      availability_zone_count = length(var.private_app_subnet_ids)
+    }
   }
 
   ebs_options {


### PR DESCRIPTION
I have tested this on DEV from local and ran through OK (after failing in Pipeline before this). I can see ES provisioned across 2 AZs now.

It still has the original change - which was to make 2 instances - so this means there are now 4 instances (2 instances in each AZ I assume). I'll check with Tony whether this is the preferred config.

I'll approve this PR now so I can continue with the deployments to INT/SBX8 - to be reviewed retrospectively