### PR TITLE
SINF-256 - made ES instance count dynamic based on AZ

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -81,6 +81,5 @@ module "elasticsearch" {
   private_app_subnet_ids = split(",", data.aws_ssm_parameter.private_app_subnet_ids.value)
   security_group_ids     = concat(local.cidr_blocks_allowed_external_ccs, local.cidr_blocks_allowed_external_spark, tolist([data.aws_vpc.scale.cidr_block]))
   es_instance_type       = var.es_instance_type
-  es_instance_count      = var.es_instance_count
   es_ebs_volume_size     = var.es_ebs_volume_size
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -43,11 +43,6 @@ variable "es_instance_type" {
   default = "t2.medium.elasticsearch"
 }
 
-variable "es_instance_count" {
-  type    = number
-  default = 2
-}
-
 variable "es_ebs_volume_size" {
   type    = number
   default = 10

--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -35,7 +35,7 @@ resource "aws_elasticsearch_domain" "main" {
 
   cluster_config {
     instance_type          = var.es_instance_type
-    instance_count         = var.es_instance_count
+    instance_count         = length(var.private_app_subnet_ids)
     zone_awareness_enabled = true
 
     zone_awareness_config {

--- a/terraform/modules/elasticsearch/variables.tf
+++ b/terraform/modules/elasticsearch/variables.tf
@@ -18,10 +18,6 @@ variable "es_instance_type" {
   type = string
 }
 
-variable "es_instance_count" {
-  type = number
-}
-
 variable "es_ebs_volume_size" {
   type = number
 }


### PR DESCRIPTION
Hit an error when deploying on SBX8 - it complained it needed 3 instances min as it was deploying on 3 AZs.

Made instance count equal AZ count (as will always have at least 2 AZs now with recent changes).

Applied locally to SBX8