### PR TITLE
SINF-400 - enabled encryption at rest and enforced https on ES

### DIFF
--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -45,4 +45,5 @@ module "deploy" {
   db_instance_class               = "db.r5.xlarge"
   spree_cluster_instances         = length(local.availability_zones)
   backup_retention_period         = 35
+  es_encrypt_at_rest              = true
 }

--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -82,4 +82,5 @@ module "elasticsearch" {
   security_group_ids     = concat(local.cidr_blocks_allowed_external_ccs, local.cidr_blocks_allowed_external_spark, tolist([data.aws_vpc.scale.cidr_block]))
   es_instance_type       = var.es_instance_type
   es_ebs_volume_size     = var.es_ebs_volume_size
+  encrypt_at_rest        = var.es_encrypt_at_rest
 }

--- a/terraform/modules/configs/deploy-all/variables.tf
+++ b/terraform/modules/configs/deploy-all/variables.tf
@@ -60,3 +60,12 @@ variable "snapshot_identifier" {
 variable "kms_cmk_rds_shared" {
   type = string
 }
+
+#####################################
+# Only available for certain ES 
+# instance types
+#####################################
+variable "es_encrypt_at_rest" {
+  type    = bool
+  default = false
+}

--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -53,6 +53,15 @@ resource "aws_elasticsearch_domain" "main" {
     security_group_ids = [aws_security_group.es.id]
   }
 
+  domain_endpoint_options {
+    enforce_https       = true
+    tls_security_policy = "Policy-Min-TLS-1-2-2019-07"
+  }
+
+  encrypt_at_rest {
+    enabled = var.encrypt_at_rest
+  }
+
   depends_on = [
     aws_iam_service_linked_role.es,
   ]

--- a/terraform/modules/elasticsearch/variables.tf
+++ b/terraform/modules/elasticsearch/variables.tf
@@ -21,3 +21,7 @@ variable "es_instance_type" {
 variable "es_ebs_volume_size" {
   type = number
 }
+
+variable "encrypt_at_rest" {
+  type = bool
+}


### PR DESCRIPTION
Enabled encryption at rest and enforced HTTPS on ElasticSearch instance.

Encryption uses default key. Only certain instance types support this - which is why there is a flag. I tested the NFT instance type on SBX1 and it worked ok.

May require a reindex of ES (seemed to on SBX1).

There is also an option to enable encryption between nodes, but did not think this was a requirement.