### PR TITLE
SINF-408 - added CW alarm if DB instance count drops below expected

### DIFF
--- a/terraform/modules/configs/deploy-all/main.tf
+++ b/terraform/modules/configs/deploy-all/main.tf
@@ -84,3 +84,11 @@ module "elasticsearch" {
   es_ebs_volume_size     = var.es_ebs_volume_size
   encrypt_at_rest        = var.es_encrypt_at_rest
 }
+
+module "cloudwatch-alarms-spree" {
+  source                  = "../../cw-alarms"
+  environment             = var.environment
+  db_cluster_name         = module.spree.db_cluster_name
+  db_name                 = "bat-spree"
+  db_expected_instance_count = length(split(",", data.aws_ssm_parameter.private_db_subnet_ids.value))
+}

--- a/terraform/modules/cw-alarms/main.tf
+++ b/terraform/modules/cw-alarms/main.tf
@@ -1,0 +1,27 @@
+#########################################################
+# Cloudwatch: Alarms
+#
+# Create performance alarms.
+#########################################################
+
+resource "aws_sns_topic" "alarms" {
+  name = "CCS-EU2-${upper(var.environment)}-CW-ALARMS-${upper(var.db_name)}-DB"
+}
+
+resource "aws_cloudwatch_metric_alarm" "task" {
+  alarm_name                = "${lower(var.db_name)}-db-task-alarm"
+  comparison_operator       = "LessThanThreshold"
+  evaluation_periods        = "1"
+  metric_name               = "CPUUtilization"
+  namespace                 = "AWS/RDS"
+  period                    = "60"
+  statistic                 = "SampleCount"
+  threshold                 = var.db_expected_instance_count
+  alarm_description         = "This metric monitors task removals"
+  insufficient_data_actions = []
+  alarm_actions             = [aws_sns_topic.alarms.arn]
+
+  dimensions = {
+    DBClusterIdentifier = var.db_cluster_name
+  }
+}

--- a/terraform/modules/cw-alarms/variables.tf
+++ b/terraform/modules/cw-alarms/variables.tf
@@ -1,0 +1,15 @@
+variable environment {
+  type = string
+}
+
+variable db_cluster_name {
+  type = string
+}
+
+variable db_name {
+  type = string
+}
+
+variable "db_expected_instance_count" {
+  type = string
+}

--- a/terraform/modules/spree/outputs.tf
+++ b/terraform/modules/spree/outputs.tf
@@ -1,0 +1,3 @@
+output "db_cluster_name" {
+  value = aws_rds_cluster.default.cluster_identifier
+}


### PR DESCRIPTION
Added CW alarm to monitor task count on DB instances and alert if instance is removed. This was never added to FaT, so probably should be retrofitted.