### PR TITLE
SINF-408 - updated cw metric db task count alarm

### DIFF
--- a/terraform/modules/cw-alarms/main.tf
+++ b/terraform/modules/cw-alarms/main.tf
@@ -11,7 +11,8 @@ resource "aws_sns_topic" "alarms" {
 resource "aws_cloudwatch_metric_alarm" "task" {
   alarm_name                = "${lower(var.db_name)}-db-task-alarm"
   comparison_operator       = "LessThanThreshold"
-  evaluation_periods        = "1"
+  evaluation_periods        = "5"
+  datapoints_to_alarm       = "3"
   metric_name               = "CPUUtilization"
   namespace                 = "AWS/RDS"
   period                    = "60"


### PR DESCRIPTION
Minor tweak - was getting false positives where it was going to alarm because it thought instance count was 2 - but opening the metrics showed it wasn't - not sure why. This tweak means it will alert after 3 minutes (in any 5 minute period)