### PR TITLE
Feature/sinf 440 es node encryption

### DIFF
--- a/terraform/environments/nft/main.tf
+++ b/terraform/environments/nft/main.tf
@@ -45,6 +45,5 @@ module "deploy" {
   db_instance_class               = "db.r5.xlarge"
   spree_cluster_instances         = length(local.availability_zones)
   backup_retention_period         = 35
-  // TODO: needs to set to 'true' after issues resolved under SINF-407
-  es_encrypt_at_rest              = false
+  es_encrypt_at_rest              = true
 }

--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -30,8 +30,8 @@ resource "aws_security_group" "es" {
 }
 
 resource "aws_elasticsearch_domain" "main" {
-  domain_name           = "scale-eu2-${lower(var.environment)}-es-spree"
-  elasticsearch_version = "7.4"
+  domain_name             = "scale-eu2-${lower(var.environment)}-es-spree"
+  elasticsearch_version   = "7.4"
 
   cluster_config {
     instance_type          = var.es_instance_type
@@ -60,6 +60,10 @@ resource "aws_elasticsearch_domain" "main" {
 
   encrypt_at_rest {
     enabled = var.encrypt_at_rest
+  }
+
+  node_to_node_encryption {
+    enabled = true
   }
 
   depends_on = [

--- a/terraform/modules/elasticsearch/main.tf
+++ b/terraform/modules/elasticsearch/main.tf
@@ -30,8 +30,8 @@ resource "aws_security_group" "es" {
 }
 
 resource "aws_elasticsearch_domain" "main" {
-  domain_name             = "scale-eu2-${lower(var.environment)}-es-spree"
-  elasticsearch_version   = "7.4"
+  domain_name           = "scale-eu2-${lower(var.environment)}-es-spree"
+  elasticsearch_version = "7.4"
 
   cluster_config {
     instance_type          = var.es_instance_type
@@ -96,6 +96,10 @@ resource "aws_elasticsearch_domain_policy" "main" {
     ]
 }
 POLICIES
+
+  depends_on = [
+    aws_elasticsearch_domain.main
+  ]
 }
 
 resource "aws_ssm_parameter" "es_url" {


### PR DESCRIPTION
SecurityHub flagged that encryption at rest was not enabled. We tried this before, but saw errors in NewRelic so rolled it back. It has been running ok (seemingly) on SBX1 for a while - so maybe worth a retry on NFT.

Also enabled node to node encryption. Again, didn't seem to work before - but seems ok SBX1 (after a reindex).

Plan would be to try this again on NFT at the weekend (given the 8 hour reindex time)

Note - only works on larger instances, so requires:

```
es_encrypt_at_rest              = true
es_instance_type                = "m5.xlarge.elasticsearch"
```

Actually - would be interesting to test if node-to-node encryption works on smaller instances (encryption at rest does not) - I may roll back my instance and test that on SBX1 now (UPDATE: done that - and node to node encryption is fine on M3 instances). 

UPDATE: also added depends_on as noticed a couple of times now the ES access policy was not always created on first pass when applying after a destroy. This was showing up as 'Forbidden' errors in NewRelic in the Spree logs.
